### PR TITLE
修复：yAxis属性类型校验支持数组，支持Y轴存在2个的情况

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -48,7 +48,7 @@ export default {
     title: Object,
     legend: Object,
     xAxis: Object,
-    yAxis: Object,
+    yAxis: [Object, Array],
     radar: Object,
     tooltip: Object,
     axisPointer: Object,


### PR DESCRIPTION
#### Check List
- [x] Every Commit message is meaningful
- [x] Synchronized with the master branch
- [x] CI passed

#### What changed
- yAxis属性类型校验支持数组

#### Breaking Change
- [ ] Yes
- [x] No
