### PR TITLE
fix: when prop is object or array, deep=true, watcher's cb always run

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -312,8 +312,10 @@ export default {
           if (~['[object Object]', '[object Array]'].indexOf(getType(this.$props[prop]))) {
             opts.deep = true
           }
-          this.$watch(prop, () => {
-            this.changeHandler()
+          this.$watch(prop, (val, oldVal) => {
+            if (val !== oldVal) {
+              this.changeHandler()
+            }
           }, opts)
         }
       })


### PR DESCRIPTION
#### Check List
- [x] Every Commit message is meaningful
- [ ] Synchronized with the master branch
- [ ] CI passed

#### What Changed


#### Breaking Change
- [ ] Yes
- [x] No

#### Document Update
- [ ] Yes
- [x] No
