### PR TITLE
fix(demo): downgrade docsify to specify version

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
   <script src="https://cdn.jsdelivr.net/npm/babel-standalone/babel.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/vuep-magic-patch@1.0.10/dist/vuep.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/echarts@latest/dist/echarts.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/echarts@4.9.0/dist/echarts.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/echarts-amap/dist/echarts-amap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/element-ui@1.4.0/lib/index.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/echarts/dist/extension/bmap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     getVuepText()
     window.addEventListener('popstate', getVuepText)
   </script>
-  <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/docsify@4.11.6/lib/docsify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/search.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify/lib/plugins/ga.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-pagination/dist/docsify-pagination.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     ]
     window.VUEP_RESOURCE = [
       "https://cdn.jsdelivr.net/npm/vue/dist/vue.min.js",
-      "https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js",
+      "https://cdn.jsdelivr.net/npm/echarts@4.9.0/dist/echarts.min.js",
       "https://cdn.jsdelivr.net/npm/echarts-amap/dist/echarts-amap.min.js",
       "https://cdn.jsdelivr.net/npm/echarts/dist/extension/bmap.min.js",
       "https://cdn.jsdelivr.net/npm/echarts-liquidfill@2.0.2/dist/echarts-liquidfill.min.js",


### PR DESCRIPTION
downgrade docsify make it compatible with vuep to show v-chart demo

Not sure what change cause issue. 

Here is [reference diff](https://github.com/docsifyjs/docsify/compare/v4.11.6...v4.12.0) for the version which not work since 4.12.0 ([release Note](https://github.com/docsifyjs/docsify/releases/tag/v4.12.0)) compare to 4.11.6 (work well with vuep)



#### Check List
- [x] Every Commit message is meaningful
- [ ] Synchronized with the master branch
- [ ] CI passed

#### What Changed


#### Breaking Change
- [ ] Yes
- [x] No

#### Document Update
- [x] Yes
- [ ] No
