### PR TITLE
fix: series合并错误

### DIFF
--- a/src/modules/extend.js
+++ b/src/modules/extend.js
@@ -14,7 +14,7 @@ export default function (options, extend) {
       if (isArray(options[attr]) && isObject(options[attr][0])) {
         // eg: [{ xx: 1 }, { xx: 2 }]
         options[attr].forEach((option, index) => {
-          options[attr][index] = Object.assign({}, option, value)
+          options[attr][index] = Object.assign({}, option, value[index])
         })
       } else if (isObject(options[attr])) {
         // eg: { xx: 1, yy: 2 }


### PR DESCRIPTION
#### Check List
- [ ] Regression test with the series attribute and the case of the extend props when the series is an array type
- [ ] Synchronized with the master branch
- [ ] CI passed

#### What Changed
When the extend props with the series attribute and the series is an array type is merged into the final configuration of echarts, each item of the series should be merged instead of the entire series array

#### Breaking Change
- [x] No

#### Document Update
- [ ] No
